### PR TITLE
One URL per panel, no reload between them

### DIFF
--- a/packages/site/content.js
+++ b/packages/site/content.js
@@ -141,3 +141,35 @@ export const SPEC_TABLE = [
     ],
   },
 ];
+
+// The panels are also pages. A link opens one directly and the application
+// switches between them without reloading; the build prerenders each route.
+export const TABS = [
+  { id: "arena", label: "Arena", icon: "arena", route: "", title: SITE.title },
+  {
+    id: "lab", label: "Bot Lab", icon: "code", route: "lab/",
+    title: "Write a robot controller - llms-robot-arena",
+  },
+  {
+    id: "tournament", label: "Tournament", icon: "trophy", route: "tournament/",
+    title: "Published standings - llms-robot-arena",
+  },
+  {
+    id: "rules", label: "Rules", icon: "book", route: "rules/",
+    title: "Arena rules and engine constants - llms-robot-arena",
+  },
+];
+
+// Controllers and their sources are reference pages, not a panel: opening one
+// leaves the application.
+export const CONTROLLERS = { label: "Controllers", route: "bots/" };
+
+export const normalizeRoute = (route) => {
+  const path = String(route).replace(/^\/+/, "").replace(/[?#].*$/, "").replace(/index\.html$/, "");
+  return path && !path.endsWith("/") ? path + "/" : path;
+};
+
+export const tabForRoute = (route) =>
+  TABS.find((tab) => tab.route === normalizeRoute(route)) ?? null;
+
+export const CONTRACT_CARD = `<div class="eyebrow">THE CONTRACT</div><h2>One function. Two commands.</h2><code>tick(sensors, memory)</code><p>Return <code>actions</code> and <code>memory</code>. All data uses world coordinates.</p><dl><dt>thrust</dt><dd>−1 reverse → +1 forward</dd><dt>turn</dt><dd>−1 clockwise → +1 counterclockwise</dd><dt>memory</dt><dd>JSON · up to 64 KB</dd></dl>`;

--- a/packages/site/prerender.js
+++ b/packages/site/prerender.js
@@ -5,7 +5,10 @@ import { SPEC_VERSION, ENGINE_VERSION } from "../sim/spec.js";
 import { botName, botDetails, botProvider } from "../bot-catalog.js";
 import { STYLE_AXES, formatStyleValue, styleLabel, styleProfiles } from "../tournament/style.js";
 import { INDEX_TERMS, compositeIndex } from "../tournament/composite.js";
-import { SITE, RULE_CARDS, HAZARD_CARDS, RULES_NOTE, ruleCards, SPEC_TABLE } from "./content.js";
+import {
+  SITE, RULE_CARDS, HAZARD_CARDS, RULES_NOTE, ruleCards, SPEC_TABLE,
+  TABS, CONTROLLERS, CONTRACT_CARD,
+} from "./content.js";
 
 export const esc = (value) =>
   String(value).replace(
@@ -17,13 +20,7 @@ export const esc = (value) =>
 export const botSlug = (bot) =>
   bot.id.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
 
-export const NAV = [
-  { path: "", label: "Arena" },
-  { path: "rules/", label: "Rules" },
-  { path: "tournament/", label: "Standings" },
-  { path: "bots/", label: "Controllers" },
-];
-
+const tabTitle = (id) => TABS.find((tab) => tab.id === id).title;
 const depthOf = (path) => (path === "" ? 0 : path.split("/").length - 1);
 const relative = (depth, path) => ("../".repeat(depth) || "./") + path;
 const absolute = (baseUrl, path) => new URL(path, baseUrl).href;
@@ -46,15 +43,15 @@ const card = (title, tag, body) =>
 const facts = (rows) =>
   table(["Field", "Value"], rows.map(([k, v]) => [esc(k), `<span class="mono">${esc(v)}</span>`]));
 
-function layout({ path, title, description, main, schema, baseUrl }) {
+function layout({ path, title, description, main, schema, baseUrl, app = false }) {
   const depth = depthOf(path);
   const to = (target) => relative(depth, target);
   const canonical = absolute(baseUrl, path);
-  const nav = NAV.map(
-    (item) =>
-      `<a class="nav-button${item.path === path ? " selected" : ""}" href="${to(item.path)}"${
-        item.path === path ? ' aria-current="page"' : ""
-      }>${esc(item.label)}</a>`,
+  const nav = TABS.map(
+    (tab) =>
+      `<a class="nav-button${tab.route === path ? " selected" : ""}" data-tab="${tab.id}" href="${to(
+        tab.route,
+      )}"${tab.route === path ? ' aria-current="page"' : ""}>${esc(tab.label)}</a>`,
   ).join("");
   return `<!doctype html>
 <html lang="en">
@@ -75,17 +72,16 @@ function layout({ path, title, description, main, schema, baseUrl }) {
   <script type="application/ld+json">${jsonLd(schema)}</script>
 </head>
 <body>
-<header class="header">
+${app ? '<div id="app">' : ""}<header class="header">
  <a class="brand" href="${to("")}" aria-label="${esc(SITE.name)}, home"><span class="brand-mark" aria-hidden="true">R<span>↗</span></span><span>llms-<span class="brand-second">robot-arena</span></span></a>
  <nav aria-label="Main navigation">${nav}</nav>
  <div class="header-end"><span class="version">SPEC ${SPEC_VERSION.replace("-draft", "")} </span></div>
 </header>
 <main>${main}</main>
-<footer class="footer"><span><a href="${SITE.repository}" title="View ${esc(SITE.name)} on GitHub">${esc(SITE.name)}</a></span><nav class="footer-links" aria-label="Reference pages">${NAV.slice(
-    1,
-  )
-    .map((item) => `<a href="${to(item.path)}">${esc(item.label)}</a>`)
-    .join("")}</nav><span>Code makes the difference.</span><span>ENGINE ${ENGINE_VERSION}</span></footer>
+<footer class="footer"><span><a href="${SITE.repository}" title="View ${esc(SITE.name)} on GitHub">${esc(SITE.name)}</a></span><nav class="footer-links" aria-label="Reference pages"><a href="${to(
+    CONTROLLERS.route,
+  )}">${esc(CONTROLLERS.label)}</a></nav><span>Code makes the difference.</span><span>ENGINE ${ENGINE_VERSION}</span></footer>
+${app ? `</div>\n<script type="module" src="${to("app.js")}"></script>` : ""}
 </body>
 </html>
 `;
@@ -111,7 +107,8 @@ function rulesPage(baseUrl) {
   const constants = SPEC_TABLE.map((group) => card(group.group, null, facts(group.rows))).join("");
   return layout({
     path: "rules/",
-    title: "Arena rules and engine constants - llms-robot-arena",
+    app: true,
+    title: tabTitle("rules"),
     description:
       "The rules of the llms-robot-arena duel: a shrinking 16 m platform, wedge flips, quadratic energy cost, hazards, victory order, and every engine constant a controller can rely on.",
     baseUrl,
@@ -190,7 +187,8 @@ function tournamentPage(standings, baseUrl) {
     .join(" · ");
   return layout({
     path: "tournament/",
-    title: "Published standings - llms-robot-arena",
+    app: true,
+    title: tabTitle("tournament"),
     description: `Bradley–Terry standings of ${standings.ranking.length} LLM-written robot controllers over ${standings.totalMatches} deterministic duels: strength, confidence intervals, play style, source metrics and craft index.`,
     baseUrl,
     schema: [
@@ -320,6 +318,58 @@ function tournamentPage(standings, baseUrl) {
     ]),
   )}
   <p class="tournament-note">Results from different engine versions or budgets are not comparable. The raw run is <a class="text-link" href="../standings.json">standings.json</a>, and each entry has its own page under <a class="text-link" href="../bots/">Controllers</a>.</p>`,
+  });
+}
+
+function labPage(example, baseUrl) {
+  return layout({
+    path: "lab/",
+    app: true,
+    title: tabTitle("lab"),
+    description:
+      "Write an autonomous robot controller in JavaScript or TypeScript, check it against the contract and run it in the browser: one tick function, thrust and turn, 64 KB of memory.",
+    baseUrl,
+    schema: [
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        headline: "Write a robot controller",
+        description:
+          "The bot contract of llms-robot-arena: one tick export, thrust and turn, JSON memory, QuickJS sandbox.",
+        url: absolute(baseUrl, "lab/"),
+        isPartOf: { "@type": "WebSite", name: SITE.name, url: baseUrl },
+        version: SPEC_VERSION,
+        proficiencyLevel: "Beginner",
+      },
+      breadcrumbs(baseUrl, [
+        { name: "Arena", path: "" },
+        { name: "Bot Lab", path: "lab/" },
+      ]),
+    ],
+    main: `${heading(
+      "CONTROLLER WORKSPACE",
+      "Your code. Your robot",
+      "The Bot Lab writes, checks and runs a controller in the browser: no install, no account, no API key. What you write stays in the page, so download the file to keep it.",
+    )}
+  <div class="rules-grid">
+   <article class="info-card">${CONTRACT_CARD}</article>
+   <article class="info-card"><span class="rule-number">SANDBOX</span><h2>QuickJS in a worker.</h2><p>One JavaScript or TypeScript file, one <code>tick</code> export, no imports and no host APIs. Sensors and memory arrive frozen and every call gets a fresh module scope, so nothing carries over except the memory you return. It runs as QuickJS WebAssembly, one worker per robot.</p></article>
+   <article class="info-card"><span class="rule-number">CONFORMANCE GATE</span><h2>Checked before it fights.</h2><p>200 snapshots and 600 inert ticks look at execution, purity, memory and timing. They say nothing about strategy: passing the gate means the controller is admissible, not that it is any good.</p></article>
+  </div>
+  ${
+    example
+      ? card(
+          "Minimal controller",
+          "PUBLIC CONTRACT MATERIAL · A STARTING TEMPLATE",
+          `<div class="source-view"><pre><code>${esc(example)}</code></pre></div>`,
+        )
+      : ""
+  }
+  <p class="tournament-note">${
+    example
+      ? "That one turns to face the opponent and drives at it, ignoring energy, holes and flames, which is why every registered controller beats it. "
+      : ""
+  }The full contract, the types and the conformity checks are in <a class="text-link" href="${SITE.repository}/blob/main/AGENTS.md">AGENTS.md</a>, and the <a class="text-link" href="../bots/">registered controllers</a> show what a complete one looks like.</p>`,
   });
 }
 
@@ -558,7 +608,8 @@ A match lasts 120 seconds at 60 Hz on a 16 × 16 m platform that starts shrinkin
 
 ## Pages
 
-${line("Arena", "", "the live simulator, controller editor and replay viewer; needs WebGL 2")}
+${line("Arena", "", "the live simulator and replay viewer; needs WebGL 2")}
+${line("Bot Lab", "lab/", "the bot contract, the sandbox limits and a minimal controller to start from")}
 ${line("Rules and engine constants", "rules/", "arena, wedge flips, energy, hazards, victory order and every published constant")}
 ${line(
   "Published standings",
@@ -607,13 +658,21 @@ const notFoundPage = (baseUrl) => `<!doctype html>
 `;
 
 // Every generated file, keyed by its path inside dist.
-export function renderSite({ index, bots, standings = null, baseUrl = SITE.url, now = new Date() }) {
+export function renderSite({
+  index,
+  bots,
+  standings = null,
+  example = "",
+  baseUrl = SITE.url,
+  now = new Date(),
+}) {
   const base = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
   const slugs = bots.map(botSlug);
   if (slugs.some((slug) => !slug) || new Set(slugs).size !== slugs.length)
     throw new Error("Bot IDs must produce unique, non-empty URL slugs.");
   const files = new Map([
     ["index.html", homePage(index, bots, standings, base)],
+    ["lab/index.html", labPage(example, base)],
     ["rules/index.html", rulesPage(base)],
     ["bots/index.html", botsPage(bots, standings, base)],
   ]);
@@ -621,6 +680,7 @@ export function renderSite({ index, bots, standings = null, baseUrl = SITE.url, 
   for (const bot of bots) files.set(`bots/${botSlug(bot)}/index.html`, botPage(bot, standings, base));
   const pages = [
     "",
+    "lab/",
     "rules/",
     ...(standings ? ["tournament/"] : []),
     "bots/",

--- a/packages/viewer/app.js
+++ b/packages/viewer/app.js
@@ -20,7 +20,8 @@ import {
   OUTRO_SECONDS,
 } from "./recorder.js";
 import { MatchAudio } from "./audio.js";
-import { RULE_CARDS, HAZARD_CARDS, RULES_NOTE, ruleCards } from "../site/content.js";
+import { CONTRACT_CARD, CONTROLLERS, HAZARD_CARDS, RULE_CARDS, RULES_NOTE, TABS, ruleCards, tabForRoute } from "../site/content.js";
+import { currentRoute, pagePath, siteUrl } from "./base.js";
 const icons = {
   arena: "M4 7 12 3l8 4v10l-8 4-8-4V7Zm0 0 8 4 8-4M12 11v10",
   code: "m8 5-6 7 6 7m8-14 6 7-6 7m-3-16-2 18",
@@ -88,24 +89,20 @@ const download = (name, data, type = "application/json") => {
   a.click();
   setTimeout(() => URL.revokeObjectURL(url), 1000);
 };
+// The panel a link asked for. Everything after that is switched in place.
+const initialTab = tabForRoute(currentRoute()) ?? TABS[0];
+const shown = (tab) => (tab === initialTab.id ? "" : " hidden");
 document.querySelector("#app").innerHTML = `
 <header class="header">
- <a class="brand" href="./" aria-label="llms-robot-arena, home"><span class="brand-mark" aria-hidden="true">R<span>↗</span></span><span>llms-<span class="brand-second">robot-arena</span></span></a>
- <nav aria-label="Main navigation">${[
-   ["arena", "Arena", "arena"],
-   ["lab", "Bot Lab", "code"],
-   ["tournament", "Tournament", "trophy"],
-   ["rules", "Rules", "book"],
- ]
-   .map(
-     ([id, label, ic]) =>
-       `<button class="nav-button ${id === "arena" ? "selected" : ""}" data-tab="${id}" aria-current="${id === "arena" ? "page" : "false"}">${icon(ic)}<span>${label}</span></button>`,
-   )
-   .join("")}</nav>
+ <a class="brand" href="${pagePath("")}" aria-label="llms-robot-arena, home"><span class="brand-mark" aria-hidden="true">R<span>↗</span></span><span>llms-<span class="brand-second">robot-arena</span></span></a>
+ <nav aria-label="Main navigation">${TABS.map(
+   (tab) =>
+     `<a class="nav-button ${tab.id === initialTab.id ? "selected" : ""}" data-tab="${tab.id}" href="${pagePath(tab.route)}" aria-current="${tab.id === initialTab.id ? "page" : "false"}">${icon(tab.icon)}<span>${tab.label}</span></a>`,
+ ).join("")}</nav>
  <div class="header-end"><span class="version">SPEC ${SPEC_VERSION.replace("-draft", "")} </span></div>
 </header>
 <main>
- <section id="panel-arena" class="panel">
+ <section id="panel-arena" class="panel"${shown("arena")}>
   <div class="page-heading"><div><div class="eyebrow">AUTONOMOUS COMBAT LAB <span>/ 01</span></div><h1>The arena decides<span>.</span></h1></div><div class="heading-actions"><select id="replay-library" aria-label="Local tournament replays" hidden><option value="">Tournament replays…</option></select><button id="import-replay" class="button outline">${icon("upload")}Import replay</button><button id="record" class="button outline" disabled>${icon("record")}Record video</button><button id="export-replay" class="button outline" disabled>${icon("download")}Export replay</button><input type="file" id="replay-file" accept=".json,application/json" hidden></div></div>
   <div class="arena-layout">
    <div class="match-surface">
@@ -138,13 +135,13 @@ document.querySelector("#app").innerHTML = `
   </div>
   <div class="arena-footer"><span><i></i>60 HZ PHYSICS</span><span>100 KG / ROBOT</span><span id="control-tag">NO MANUAL CONTROL</span><span id="hash-label">SHA-256 · HASH EVERY 60 TICKS</span></div>
  </section>
- <section id="panel-lab" class="panel" hidden>
+ <section id="panel-lab" class="panel"${shown("lab")}>
   <div class="page-heading"><div><div class="eyebrow">CONTROLLER WORKSPACE <span>/ 02</span></div><h1>Your code. Your robot<span>.</span></h1></div><button id="new-bot" class="button accent">${icon("plus")}New controller</button></div>
   <div class="lab-layout"><div class="editor-panel"><div class="editor-toolbar"><select id="edit-bot" aria-label="Controller to edit"></select><select id="source-language" aria-label="Controller file type"><option value="js">JavaScript (.js)</option><option value="ts">TypeScript (.ts)</option></select></div><div class="editor-file">${icon("code", 16)}<span id="editor-filename">controller.js</span><span id="unsaved" class="unsaved" hidden>Unsaved changes</span></div><div class="editor-body"><pre id="line-numbers" aria-hidden="true"></pre><textarea id="code-editor" aria-label="Controller source" spellcheck="false" autocapitalize="off" autocomplete="off" wrap="off"></textarea></div><div class="editor-footer"><input id="bot-name" aria-label="Model name" placeholder="Model name" maxlength="80"><select id="bot-provider" aria-label="Model provider"><option value="">No provider</option><option>OpenAI</option><option>Anthropic</option></select><button id="download-bot" class="button outline">${icon("download")}.js file</button><button id="save-bot" class="button accent">Save controller</button></div></div>
-   <aside class="lab-sidebar"><div class="info-card"><div class="eyebrow">THE CONTRACT</div><h2>One function. Two commands.</h2><code>tick(sensors, memory)</code><p>Return <code>actions</code> and <code>memory</code>. All data uses world coordinates.</p><dl><dt>thrust</dt><dd>−1 reverse → +1 forward</dd><dt>turn</dt><dd>−1 clockwise → +1 counterclockwise</dd><dt>memory</dt><dd>JSON · up to 64 KB</dd></dl></div><div class="info-card gate-card"><div class="eyebrow">CONFORMANCE GATE</div><h2>Validate the contract.</h2><p>200 snapshots and 600 inert ticks. These checks offer no combat advice.</p><button id="run-gate" class="button outline full-width">${icon("check")}Check controller</button><div id="gate-results" aria-live="polite"></div></div><p class="side-hint">Edits here are iterative experimentation. For a one-shot benchmark, follow AGENTS.md and use the project CLI.</p></aside>
+   <aside class="lab-sidebar"><div class="info-card">${CONTRACT_CARD}</div><div class="info-card gate-card"><div class="eyebrow">CONFORMANCE GATE</div><h2>Validate the contract.</h2><p>200 snapshots and 600 inert ticks. These checks offer no combat advice.</p><button id="run-gate" class="button outline full-width">${icon("check")}Check controller</button><div id="gate-results" aria-live="polite"></div></div><p class="side-hint">Edits here are iterative experimentation. For a one-shot benchmark, follow AGENTS.md and use the project CLI.</p></aside>
   </div>
  </section>
- <section id="panel-tournament" class="panel" hidden>
+ <section id="panel-tournament" class="panel"${shown("tournament")}>
   <div class="page-heading"><div><div class="eyebrow">TOURNAMENT <span>/ 03</span></div><h1>Earn your ranking<span>.</span></h1></div><div class="heading-actions"><button id="export-report" class="button outline" disabled>${icon("download")}.md report</button><button id="export-ranking" class="button outline" disabled>${icon("download")}Export results</button></div></div>
   <div class="tournament-setup"><div><span class="eyebrow">EXHIBITION TOURNAMENT</span><h2>More action. Fewer matches.</h2><label class="field-label" for="tournament-format">FORMAT</label><select id="tournament-format"><option value="quick">Quick rounds (up to 3 rounds)</option><option value="round-robin">Full round robin (20 matches per pair)</option></select><p id="tournament-description"></p><div id="tournament-bots" class="bot-checks"></div></div><button id="run-tournament" class="button accent">${icon("trophy")}Start tournament</button></div>
   <div id="tournament-progress" class="tournament-progress" hidden><div><strong id="tournament-status">Checking controllers…</strong><button id="cancel-tournament" class="button quiet">Cancel</button></div><progress max="1" value="0"></progress></div>
@@ -156,13 +153,13 @@ document.querySelector("#app").innerHTML = `
   <div id="tournament-matches" class="tournament-matches"></div>
   <p class="tournament-note">Regularized Bradley–Terry: mean strength = 100. Quick rounds sample different opponents with one seed and both spawns per pairing; they do not estimate confidence intervals. Full round robin adds 95% seed-bootstrap intervals when complete. Results remain provisional while running or after cancellation. Completed replays stay available until the next tournament or page reload. Browser results are exhibitions; the standard evaluation protocol is available through the CLI. The published standings shown when this page opens come from a repository run; starting a tournament replaces them with your own results.</p>
  </section>
- <section id="panel-rules" class="panel" hidden>
+ <section id="panel-rules" class="panel"${shown("rules")}>
   <div class="page-heading"><div><div class="eyebrow">SPEC ${SPEC_VERSION.replace("-draft", "")} <span>/ 04</span></div><h1>Same hardware. Different minds<span>.</span></h1></div></div>
   <div class="rules-grid">${ruleCards(RULE_CARDS)}</div>
   <div class="rules-grid hazard-rules">${ruleCards(HAZARD_CARDS)}</div>
   <div class="review-note"><strong>${RULES_NOTE.title}</strong><p>${RULES_NOTE.body}</p></div>
  </section>
-</main><footer class="footer"><span><a href="https://github.com/nigrosimone/llms-robot-arena" title="View llms-robot-arena on GitHub">llms-robot-arena</a></span><nav class="footer-links" aria-label="Reference pages"><a href="./rules/">Rules</a><a href="./tournament/">Standings</a><a href="./bots/">Controllers</a></nav><span>Code makes the difference.</span><span>ENGINE ${ENGINE_VERSION}</span></footer><div id="toast" role="status" aria-live="polite" hidden></div>`;
+</main><footer class="footer"><span><a href="https://github.com/nigrosimone/llms-robot-arena" title="View llms-robot-arena on GitHub">llms-robot-arena</a></span><nav class="footer-links" aria-label="Reference pages"><a href="${pagePath(CONTROLLERS.route)}">${CONTROLLERS.label}</a></nav><span>Code makes the difference.</span><span>ENGINE ${ENGINE_VERSION}</span></footer><div id="toast" role="status" aria-live="polite" hidden></div>`;
 function toast(message, error = false) {
   const el = $("#toast");
   el.textContent = message;
@@ -193,17 +190,32 @@ function refreshBotOptions() {
 refreshBotOptions();
 renderRobotCards(builtins.slice(0, 2));
 $("#bot-b").value = "1";
-document.querySelectorAll("[data-tab]").forEach((btn) =>
-  btn.addEventListener("click", () => {
-    const tab = btn.dataset.tab;
-    document
-      .querySelectorAll(".panel")
-      .forEach((p) => (p.hidden = p.id !== "panel-" + tab));
-    document.querySelectorAll("[data-tab]").forEach((b) => {
-      b.classList.toggle("selected", b === btn);
-      b.setAttribute("aria-current", b === btn ? "page" : "false");
-    });
-  }),
+// Each panel has its own address. Switching one pushes it, so the back button
+// and a shared link land on the same panel, and nothing is simulated twice.
+function selectTab(id, { push = false } = {}) {
+  const tab = TABS.find((t) => t.id === id) ?? TABS[0];
+  document
+    .querySelectorAll(".panel")
+    .forEach((p) => (p.hidden = p.id !== "panel-" + tab.id));
+  document.querySelectorAll("[data-tab]").forEach((link) => {
+    const selected = link.dataset.tab === tab.id;
+    link.classList.toggle("selected", selected);
+    link.setAttribute("aria-current", selected ? "page" : "false");
+  });
+  document.title = tab.title;
+  if (push) history.pushState(null, "", pagePath(tab.route) + location.search);
+  if (tab.id === "arena") armArena();
+}
+addEventListener("click", (event) => {
+  const link = event.target.closest?.("a[data-tab]");
+  // Modified clicks belong to the browser: a new tab must still get the page.
+  if (!link || event.defaultPrevented || event.button !== 0) return;
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+  event.preventDefault();
+  selectTab(link.dataset.tab, { push: true });
+});
+addEventListener("popstate", () =>
+  selectTab((tabForRoute(currentRoute()) ?? TABS[0]).id),
 );
 // One card per robot: a duel keeps two, a rumble grows the grid.
 function renderRobotCards(entries) {
@@ -1181,7 +1193,7 @@ document.addEventListener("keydown", (e) => {
   }
 });
 async function loadReplayUrl(path) {
-  const url = new URL(path, location.href);
+  const url = siteUrl(path);
   if (url.origin !== location.origin)
     throw Error("The replay must be hosted on the same server.");
   const response = await fetch(url);
@@ -1201,7 +1213,7 @@ $("#replay-library").onchange = async (e) => {
   }
 };
 // Standings published with the repository; starting a tournament replaces them.
-fetch("./standings.json")
+fetch(siteUrl("standings.json"))
   .then((r) => (r.ok ? r.json() : null))
   .then((published) => {
     if (report || !published?.ranking?.length) return;
@@ -1210,7 +1222,7 @@ fetch("./standings.json")
     renderRanking();
   })
   .catch(() => {});
-fetch("./replays.json")
+fetch(siteUrl("replays.json"))
   .then((r) => (r.ok ? r.json() : []))
   .then((names) => {
     if (!Array.isArray(names) || !names.length) return;
@@ -1225,12 +1237,22 @@ fetch("./replays.json")
   })
   .catch(() => {});
 const requestedReplay = new URLSearchParams(location.search).get("replay");
-if (requestedReplay) {
-  loadReplayUrl(requestedReplay).catch((e) => {
-    if (viewer) $("#stage-loading").hidden = true;
-    toast(e.message + " You can simulate a new match.", true);
-  });
-} else {
-  applyMatchSettings();
-  $("#simulate").click();
+let armed = false;
+// The opening match waits for the arena: a visitor who followed a link to the
+// rules should not pay for a simulation they are not looking at.
+function armArena() {
+  // A tournament replay opened from its own panel is already on the stage: the
+  // opening match must not overwrite what the visitor asked to watch.
+  if (armed || replay) return;
+  armed = true;
+  if (requestedReplay) {
+    loadReplayUrl(requestedReplay).catch((e) => {
+      if (viewer) $("#stage-loading").hidden = true;
+      toast(e.message + " You can simulate a new match.", true);
+    });
+  } else {
+    applyMatchSettings();
+    $("#simulate").click();
+  }
 }
+if (initialTab.id === "arena") armArena();

--- a/packages/viewer/base.js
+++ b/packages/viewer/base.js
@@ -1,0 +1,9 @@
+// Assets live next to the bundle, never next to the page that loaded it: the
+// static page at /rules/ still has to reach /standings.json and /replays/.
+import { normalizeRoute } from "../site/content.js";
+
+export const siteRoot = new URL("./", import.meta.url);
+export const siteUrl = (path) => new URL(path, siteRoot);
+export const pagePath = (route) => new URL(route, siteRoot).pathname;
+export const currentRoute = () =>
+  normalizeRoute(location.pathname.slice(siteRoot.pathname.length));

--- a/packages/viewer/soundtrack.js
+++ b/packages/viewer/soundtrack.js
@@ -5,7 +5,8 @@
 //
 // The file is local and is not part of the repository. Without it the viewer
 // stays silent, and only the sound effects play.
-export const TRACK_URL = "./music/bed.mp3";
+import { siteUrl } from "./base.js";
+export const TRACK_URL = siteUrl("music/bed.mp3").href;
 const clamp01 = (n) => (n < 0 ? 0 : n > 1 ? 1 : n);
 
 export class Soundtrack {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -57,10 +57,14 @@ await build({
 await cp(resolve(root, "packages/viewer/public"), dist, { recursive: true });
 await writeFile(resolve(dist, "replays.json"), "[]\n");
 // Static pages, sitemap, robots and llms.txt for readers that never run the app.
+// The Bot Lab page shows the minimal controller from the specification itself,
+// so the template on the site is always the template agents are given.
+const specification = await readFile(resolve(root, "AGENTS.md"), "utf8");
 const site = renderSite({
   index: await readFile(resolve(dist, "index.html"), "utf8"),
   bots,
   standings: await readFile(resolve(dist, "standings.json"), "utf8").then(JSON.parse, () => null),
+  example: specification.match(/### Minimal example\s+```\w*\n([\s\S]*?)```/)?.[1] ?? "",
   ...(process.env.SITE_URL ? { baseUrl: process.env.SITE_URL } : {}),
 });
 for (const [path, content] of site) {

--- a/tests/site.test.js
+++ b/tests/site.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { renderSite, botSlug } from "../packages/site/prerender.js";
-import { RULE_CARDS, HAZARD_CARDS, SITE } from "../packages/site/content.js";
+import { RULE_CARDS, HAZARD_CARDS, SITE, TABS, normalizeRoute, tabForRoute } from "../packages/site/content.js";
 import { projectRoot } from "../packages/bot-catalog-node.js";
 
 const BASE = "https://example.test/arena/";
@@ -50,16 +50,29 @@ const standings = () => ({
   generatedAt: "2026-01-02T03:04:05.000Z",
   environment: { node: "v24.0.0", platform: "linux", arch: "x64", cpu: "Test CPU" },
 });
+const EXAMPLE = "export function tick(s, m) {\n  return { actions: { thrust: 1, turn: 0 }, memory: m };\n}\n";
 const render = async (overrides = {}) =>
-  renderSite({ index: await shell(), bots: bots(), standings: standings(), baseUrl: BASE, ...overrides });
+  renderSite({
+    index: await shell(),
+    bots: bots(),
+    standings: standings(),
+    example: EXAMPLE,
+    baseUrl: BASE,
+    ...overrides,
+  });
 
 test("every page is a complete document with its own title, description, canonical and valid JSON-LD", async () => {
   const files = await render();
   const pages = [...files].filter(([path]) => path.endsWith(".html") && path !== "404.html");
-  assert.deepEqual(
-    pages.map(([path]) => path).sort(),
-    ["bots/alpha-max/index.html", "bots/beta-bot/index.html", "bots/index.html", "index.html", "rules/index.html", "tournament/index.html"],
-  );
+  assert.deepEqual(pages.map(([path]) => path).sort(), [
+    "bots/alpha-max/index.html",
+    "bots/beta-bot/index.html",
+    "bots/index.html",
+    "index.html",
+    "lab/index.html",
+    "rules/index.html",
+    "tournament/index.html",
+  ]);
   const titles = new Set(), descriptions = new Set();
   for (const [path, html] of pages) {
     const url = new URL(path.replace(/index\.html$/, ""), BASE).href;
@@ -106,6 +119,9 @@ test("rules, standings and controller pages carry the content they exist for", a
   const rules = files.get("rules/index.html");
   for (const card of [...RULE_CARDS, ...HAZARD_CARDS]) assert.ok(rules.includes(card.title), card.number);
   assert.ok(rules.includes("300 <small>starting energy</small>"), "spec constants must be interpolated");
+  const lab = files.get("lab/index.html");
+  assert.ok(lab.includes("tick(sensors, memory)"), "the contract is the point of the page");
+  assert.ok(lab.includes(EXAMPLE.trimEnd()), "the minimal controller comes from the specification");
   const tournament = files.get("tournament/index.html");
   for (const text of ["Alpha 1", "Beta 2", "Craft index", "Play style", "Implementation", "120.0"])
     assert.ok(tournament.includes(text), text);
@@ -115,10 +131,40 @@ test("rules, standings and controller pages carry the content they exist for", a
   assert.doesNotMatch(alpha.replace(/<script type="application\/ld\+json">[\s\S]*?<\/script>/g, ""), /<script/);
 });
 
+test("the panel pages boot the application, the reference pages stay plain", async () => {
+  const files = await render();
+  for (const tab of TABS) {
+    const path = tab.route + "index.html";
+    const html = files.get(path);
+    assert.ok(html.includes('<div id="app">'), `${path} must give its content to the application`);
+    assert.match(html, /<script type="module" src="[^"]*app\.js"><\/script>/, path);
+    assert.equal(html.match(/<title>(.*?)<\/title>/)[1], tab.title, path);
+    // What the application intercepts has to be a real link for a crawler.
+    if (tab.route)
+      for (const other of TABS)
+        assert.ok(html.includes(`data-tab="${other.id}"`), `${path} must link ${other.id}`);
+  }
+  for (const path of ["bots/index.html", "bots/alpha-max/index.html"]) {
+    assert.doesNotMatch(files.get(path), /src="[^"]*app\.js"/, path);
+    assert.ok(!files.get(path).includes('<div id="app">'), path);
+  }
+});
+
+test("a route names one panel, whatever shape the URL arrives in", () => {
+  for (const [route, id] of [
+    ["", "arena"], ["index.html", "arena"], ["lab/", "lab"], ["rules", "rules"],
+    ["rules/index.html", "rules"], ["tournament/?seed=3", "tournament"],
+  ])
+    assert.equal(tabForRoute(route)?.id, id, route);
+  for (const route of ["bots/", "bots/alpha-max/", "nowhere/"])
+    assert.equal(tabForRoute(route), null, route);
+  assert.equal(normalizeRoute("/rules"), "rules/");
+});
+
 test("sitemap, robots and llms.txt describe exactly the pages that exist", async () => {
   const files = await render();
   const urls = [...files.get("sitemap.xml").matchAll(/<loc>(.*?)<\/loc>/g)].map(m => m[1]);
-  const expected = ["", "rules/", "tournament/", "bots/", "bots/alpha-max/", "bots/beta-bot/"].map(
+  const expected = ["", "lab/", "rules/", "tournament/", "bots/", "bots/alpha-max/", "bots/beta-bot/"].map(
     path => new URL(path, BASE).href,
   );
   assert.deepEqual([...urls].sort(), [...expected].sort());


### PR DESCRIPTION
The panels were tabs inside one page, so a link could only open the arena, and the static pages added in #2 were a dead end: leaving one meant a full reload.

Every panel is now a page: `/`, `/lab/`, `/tournament/`, `/rules/`. The build prerenders all four with their content, and the application takes over on load and switches panels with `pushState` and `popstate`. The opening match waits for the arena, so arriving on the rules does not simulate anything. Assets now resolve from the bundle instead of the page, otherwise standings, replays and the soundtrack break under `/rules/`. `/bots/` and the controller pages stay plain: they have no panel.

New `/lab/` page with the bot contract and the minimal controller read from AGENTS.md at build time, so the template on the site is the one agents are given.

`tests/site.test.js` adds the route mapping, the panel pages carrying the application and the reference pages staying without it.