### PR TITLE
Render the tournament panel with lit-html

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@jitl/quickjs-singlefile-browser-release-sync": "0.31.0",
         "@noble/hashes": "1.8.0",
+        "lit-html": "3.3.3",
         "quickjs-emscripten": "0.31.0",
         "three": "0.180.0",
         "typescript": "5.9.3"
@@ -526,6 +527,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.10",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
@@ -566,6 +573,15 @@
         "@esbuild/win32-arm64": "0.25.10",
         "@esbuild/win32-ia32": "0.25.10",
         "@esbuild/win32-x64": "0.25.10"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/quickjs-emscripten": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "three": "0.180.0",
+    "lit-html": "3.3.3",
     "quickjs-emscripten": "0.31.0",
     "@jitl/quickjs-singlefile-browser-release-sync": "0.31.0",
     "typescript": "5.9.3",

--- a/packages/viewer/app.js
+++ b/packages/viewer/app.js
@@ -7,8 +7,6 @@ import { robotColor } from "./palette.js";
 import { botName, botDetails } from "../bot-catalog.js";
 import { sortedBotOptions, controllerExtension, controllerFilename } from "./controllers.js";
 import { exhibitionSchedule } from "../tournament/exhibition.js";
-import { STYLE_AXES, formatStyleValue, styleLabel, styleProfiles } from "../tournament/style.js";
-import { INDEX_TERMS, compositeIndex } from "../tournament/composite.js";
 import { readMatchSettings, matchSettingsSearch } from "./match-link.js";
 import {
   MatchRecorder,
@@ -22,32 +20,12 @@ import {
 import { MatchAudio } from "./audio.js";
 import { CONTRACT_CARD, CONTROLLERS, HAZARD_CARDS, RULE_CARDS, RULES_NOTE, TABS, ruleCards, tabForRoute } from "../site/content.js";
 import { currentRoute, pagePath, siteUrl } from "./base.js";
-const icons = {
-  arena: "M4 7 12 3l8 4v10l-8 4-8-4V7Zm0 0 8 4 8-4M12 11v10",
-  code: "m8 5-6 7 6 7m8-14 6 7-6 7m-3-16-2 18",
-  trophy:
-    "M8 3h8v8a4 4 0 0 1-8 0V3Zm0 2H4v3a4 4 0 0 0 4 4m8-7h4v3a4 4 0 0 1-4 4m-4 3v6m-4 0h8",
-  book: "M4 3h13a3 3 0 0 1 3 3v15H7a3 3 0 0 1-3-3V3Zm0 14h16M8 7h8m-8 4h6",
-  play: "m8 4 12 8-12 8V4Z",
-  pause: "M8 4v16M16 4v16",
-  download: "M12 3v12m-5-5 5 5 5-5M4 16v5h16v-5",
-  upload: "M12 16V4m-5 5 5-5 5 5M4 17v4h16v-4",
-  reset: "M3 10a9 9 0 1 1 1 7M3 4v6h6",
-  expand: "M8 3H3v5m13-5h5v5M3 16v5h5m13-5v5h-5",
-  arrow: "M4 12h16m-6-6 6 6-6 6",
-  bolt: "m13 2-9 12h7l-1 8 10-13h-8l1-7Z",
-  check: "m4 12 5 5L20 6",
-  close: "m5 5 14 14M19 5 5 19",
-  plus: "M12 4v16M4 12h16",
-  settings: "M4 7h16M4 17h16M8 4v6m8 4v6",
-  swap: "M4 7h16l-4-4M20 17H4l4 4",
-  record: "M12 5a7 7 0 1 0 0 14 7 7 0 0 0 0-14Z",
-  sound: "M4 9h4l5-4v14l-5-4H4V9Zm12 0a4 4 0 0 1 0 6m3-9a8 8 0 0 1 0 12",
-  mute: "M4 9h4l5-4v14l-5-4H4V9Zm12 1 6 6m0-6-6 6",
-  stop: "M6 6h12v12H6Z",
-};
-const icon = (name, size = 18) =>
-  `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="${icons[name] ?? icons.arena}"/></svg>`;
+import { icon } from "./icons.js";
+import { clock } from "./format.js";
+import { render, nothing } from "lit-html";
+import {
+  emptyRanking, rankingTemplate, styleTemplate, indexTemplate, codeTemplate, matchesTemplate,
+} from "./tournament-view.js";
 const esc = (s) =>
   String(s).replace(
     /[&<>"']/g,
@@ -79,8 +57,6 @@ let replay = null,
   introStart = null,
   introTimer = null;
 const $ = (s) => document.querySelector(s);
-const clock = (t) =>
-  `${String(Math.floor(t / 60)).padStart(2, "0")}:${String(Math.floor(t % 60)).padStart(2, "0")}`;
 const download = (name, data, type = "application/json") => {
   const url = URL.createObjectURL(new Blob([data], { type }));
   const a = document.createElement("a");
@@ -1058,11 +1034,15 @@ $("#run-tournament").onclick = () => {
   $("#tournament-gates").hidden = true;
   $("#export-ranking").disabled = true;
   $("#export-report").disabled = true;
-  $("#ranking-surface").innerHTML = '<div class="empty-ranking"><h2>Checking controllers…</h2><p>The provisional ranking updates after every completed match.</p></div>';
-  $("#tournament-style").innerHTML = "";
-  $("#tournament-code").innerHTML = "";
-  $("#tournament-index").innerHTML = "";
-  $("#tournament-matches").innerHTML = "";
+  render(
+    emptyRanking(
+      "Checking controllers…",
+      "The provisional ranking updates after every completed match.",
+    ),
+    $("#ranking-surface"),
+  );
+  for (const id of ["#tournament-style", "#tournament-code", "#tournament-index", "#tournament-matches"])
+    render(nothing, $(id));
   $("#cancel-tournament").hidden = false;
   $("#tournament-progress").hidden = false;
   $("#tournament-progress progress").value = 0;
@@ -1070,85 +1050,31 @@ $("#run-tournament").onclick = () => {
   startOperation("tournament", { bots: selected, format: $("#tournament-format").value });
 };
 function renderRanking() {
-  const rows = report.ranking;
   $("#export-ranking").disabled = false;
   $("#export-report").disabled = false;
-  const heading = report.published
-    ? "Published standings"
-    : report.status === "complete" ? "Final ranking" : "Provisional ranking";
-  const format = report.format === "quick" ? "QUICK ROUNDS" : "ROUND ROBIN";
-  const tag = report.published
-    ? `PUBLISHED · ${report.records.length} MATCHES · ${format}${report.generatedAt ? " · " + esc(report.generatedAt.slice(0, 10)) : ""}`
-    : `${report.records.length} / ${report.totalMatches} MATCHES · ${format} · ${esc(report.status.toUpperCase())}`;
-  $("#ranking-surface").innerHTML =
-    `<div class="ranking-header"><h2>${heading}</h2><span class="tag">${tag}</span></div><div class="table-scroll"><table><thead><tr><th>#</th><th>Controller</th><th>Bradley–Terry</th><th>95% CI</th><th>Score %</th><th>W / D / L</th><th>Δ Flip</th><th>Ring-out + / −</th><th>Mean energy</th><th>First contact</th><th>Violations / match</th><th>Timeouts</th></tr></thead><tbody>${rows.map((r, i) => `<tr><td class="rank-number">${String(i + 1).padStart(2, "0")}</td><td><strong>${esc(botName(r))}</strong><small>${esc(botDetails(r))}</small></td><td class="bt-score">${r.score.toFixed(1)}</td><td class="mono">${r.ci?.map((n) => n.toFixed(1)).join(" – ") ?? "—"}</td><td>${(r.winRate * 100).toFixed(1)}%</td><td class="mono">${r.wins} / ${r.draws} / ${r.matches - r.wins - r.draws}</td><td>${r.flipDifferential > 0 ? "+" : ""}${r.flipDifferential}</td><td>${r.ringOutsInflicted} / ${r.ringOutsTaken}</td><td>${r.meanEnergy.toFixed(1)}</td><td>${r.meanFirstContactTick === null ? "—" : (r.meanFirstContactTick / 60).toFixed(1) + " s"}</td><td>${r.violationsPerMatch.toFixed(2)}</td><td>${r.timeouts}</td></tr>`).join("")}</tbody></table></div>`;
+  render(rankingTemplate(report), $("#ranking-surface"));
   renderStyle();
   renderCode();
   renderIndex();
 }
-// One radar per controller: the axes are scaled against the rest of the roster,
-// so the shape compares controllers instead of measuring them absolutely.
-function radarShape(profile) {
-  const point = (index, radius) => {
-    const angle = (Math.PI * 2 * index) / STYLE_AXES.length - Math.PI / 2;
-    return [60 + radius * Math.cos(angle), 60 + radius * Math.sin(angle)];
-  };
-  const ring = radius =>
-    STYLE_AXES.map((_, i) => point(i, radius).map(n => n.toFixed(1)).join(",")).join(" ");
-  const shape = STYLE_AXES
-    .map((axis, i) => point(i, 12 + 34 * Math.min(1, Math.max(0, profile[axis.key]))).map(n => n.toFixed(1)).join(","))
-    .join(" ");
-  const spokes = STYLE_AXES.map((_, i) => {
-    const [x, y] = point(i, 46);
-    return `<line class="radar-grid" x1="60" y1="60" x2="${x.toFixed(1)}" y2="${y.toFixed(1)}"/>`;
-  }).join("");
-  const labels = STYLE_AXES.map((axis, i) => {
-    const [x, y] = point(i, 54);
-    // Left of the centre the text runs outwards to the left, right of it to the right.
-    const anchor = x > 61 ? "start" : x < 59 ? "end" : "middle";
-    const dx = anchor === "start" ? 4 : anchor === "end" ? -4 : 0;
-    const dy = y > 61 ? 8 : y < 59 ? 0 : 3;
-    return `<text class="radar-label" x="${(x + dx).toFixed(1)}" y="${(y + dy).toFixed(1)}" text-anchor="${anchor}">${esc(axis.short ?? axis.label)}</text>`;
-  }).join("");
-  return `<svg viewBox="-40 -8 200 142" role="img" aria-hidden="true"><polygon class="radar-grid" points="${ring(46)}"/><polygon class="radar-grid" points="${ring(23)}"/>${spokes}<polygon class="radar-shape" points="${shape}"/>${labels}</svg>`;
-}
 function renderStyle() {
-  const profiles = styleProfiles(report.ranking);
-  $("#tournament-style").innerHTML = profiles
-    ? `<div class="ranking-header"><h2>Play style</h2><span class="tag">MEASURED OVER THE SAME MATCHES · SCALED ON THIS ROSTER</span></div><div class="style-cards">${report.ranking.map((r, i) => `<article class="style-card"><header><strong>${esc(botName(r))}</strong><span class="tag">${esc(styleLabel(profiles[i]))}</span></header>${radarShape(profiles[i])}<dl>${STYLE_AXES.map(axis => `<div><dt>${esc(axis.label)}</dt><dd>${esc(formatStyleValue(axis, r.style))}</dd></div>`).join("")}</dl></article>`).join("")}</div>`
-    : "";
+  render(styleTemplate(report), $("#tournament-style"));
 }
-// Results and source folded into one number. The ranking stays the ranking.
 function renderIndex() {
-  const rows = compositeIndex(report);
-  $("#tournament-index").innerHTML = rows
-    ? `<div class="ranking-header"><h2>Craft index</h2><span class="tag">RESULTS AND SOURCE · NOT THE RANKING</span></div><div class="table-scroll"><table><thead><tr><th>Controller</th><th>Craft index</th>${INDEX_TERMS.map(term => `<th>${esc(term.label)} · ${Math.round(term.weight * 100)}%</th>`).join("")}</tr></thead><tbody>${report.ranking.map((row, i) => `<tr><td><strong>${esc(botName(row))}</strong></td><td class="bt-score">${rows[i].index.toFixed(1)}</td>${INDEX_TERMS.map(term => `<td class="mono">${rows[i].terms[term.key] === null ? "—" : rows[i].terms[term.key].toFixed(2)}</td>`).join("")}</tr>`).join("")}</tbody></table></div>`
-    : "";
+  render(indexTemplate(report), $("#tournament-index"));
 }
-// Static source measurements, published with the standings.
 function renderCode() {
-  const order = new Map(report.ranking.map((row, i) => [row.id, i]));
-  const rows = (report.bots ?? [])
-    .filter(bot => bot.code)
-    .sort((x, y) => (order.get(x.id) ?? Infinity) - (order.get(y.id) ?? Infinity));
-  $("#tournament-code").innerHTML = rows.length
-    ? `<div class="ranking-header"><h2>Implementation</h2><span class="tag">MEASURED FROM THE SUBMITTED SOURCE</span></div><div class="table-scroll"><table><thead><tr><th>Controller</th><th>Language</th><th>Lines</th><th>Code</th><th>Comments</th><th>Functions</th><th>Cyclomatic</th><th>Max nesting</th><th>Size</th></tr></thead><tbody>${rows.map(bot => `<tr><td><strong>${esc(botName(bot))}</strong></td><td>${esc(bot.code.language)}</td><td class="mono">${bot.code.lines}</td><td class="mono">${bot.code.codeLines}</td><td class="mono">${bot.code.commentLines}</td><td class="mono">${bot.code.functions}</td><td class="mono">${bot.code.complexity}</td><td class="mono">${bot.code.maxDepth}</td><td class="mono">${(bot.code.bytes / 1024).toFixed(1)} kB</td></tr>`).join("")}</tbody></table></div>`
-    : "";
+  render(codeTemplate(report), $("#tournament-code"));
+}
+function watchMatch(index) {
+  const completed = tournamentReplays.get(index);
+  if (!completed) return;
+  loadReplay(completed, true);
+  $('[data-tab="arena"]').click();
 }
 function renderTournamentMatches() {
-  $("#tournament-matches").innerHTML = report.records.length
-    ? `<div class="ranking-header"><h2>Completed matches</h2><span class="tag">WATCH WHILE THE TOURNAMENT RUNS</span></div><div class="table-scroll"><table><thead><tr><th>#</th><th>Round</th><th>Match</th><th>Seed / spawn</th><th>Result</th><th>Replay</th></tr></thead><tbody>${report.records.map((r, i) => `<tr><td>${i + 1}</td><td>${r.round}</td><td>${esc(botName(report.bots[r.a]))} vs ${esc(botName(report.bots[r.b]))}</td><td>${r.seed} / ${r.mirrored ? "Mirrored" : "Standard"}</td><td>${r.score === 0.5 ? "Draw" : esc(botName(report.bots[r.score === 1 ? r.a : r.b])) + " wins"}<small>${esc(r.reason)} · ${clock(r.ticks / 60)}</small></td><td><button class="button outline" data-watch-match="${i}">${icon("play")}Watch</button></td></tr>`).reverse().join("")}</tbody></table></div>`
-    : "";
+  render(matchesTemplate(report, watchMatch), $("#tournament-matches"));
 }
-$("#tournament-matches").onclick = event => {
-  const button = event.target.closest("[data-watch-match]");
-  if (!button) return;
-  const completed = tournamentReplays.get(Number(button.dataset.watchMatch));
-  if (completed) {
-    loadReplay(completed, true);
-    $('[data-tab="arena"]').click();
-  }
-};
 $("#export-report").onclick = () => {
   if (report) download("RESULTS.md", renderReport(report), "text/markdown");
 };

--- a/packages/viewer/format.js
+++ b/packages/viewer/format.js
@@ -1,0 +1,3 @@
+// Match time as mm:ss, the same on the stage clock and in the results table.
+export const clock = (t) =>
+  `${String(Math.floor(t / 60)).padStart(2, "0")}:${String(Math.floor(t % 60)).padStart(2, "0")}`;

--- a/packages/viewer/icons.js
+++ b/packages/viewer/icons.js
@@ -1,0 +1,32 @@
+// One 24 × 24 stroke path per name. The string form builds markup by hand, the
+// template form is bound by lit-html; both draw the same icon.
+import { html } from "lit-html";
+
+const icons = {
+  arena: "M4 7 12 3l8 4v10l-8 4-8-4V7Zm0 0 8 4 8-4M12 11v10",
+  code: "m8 5-6 7 6 7m8-14 6 7-6 7m-3-16-2 18",
+  trophy:
+    "M8 3h8v8a4 4 0 0 1-8 0V3Zm0 2H4v3a4 4 0 0 0 4 4m8-7h4v3a4 4 0 0 1-4 4m-4 3v6m-4 0h8",
+  book: "M4 3h13a3 3 0 0 1 3 3v15H7a3 3 0 0 1-3-3V3Zm0 14h16M8 7h8m-8 4h6",
+  play: "m8 4 12 8-12 8V4Z",
+  pause: "M8 4v16M16 4v16",
+  download: "M12 3v12m-5-5 5 5 5-5M4 16v5h16v-5",
+  upload: "M12 16V4m-5 5 5-5 5 5M4 17v4h16v-4",
+  reset: "M3 10a9 9 0 1 1 1 7M3 4v6h6",
+  expand: "M8 3H3v5m13-5h5v5M3 16v5h5m13-5v5h-5",
+  arrow: "M4 12h16m-6-6 6 6-6 6",
+  bolt: "m13 2-9 12h7l-1 8 10-13h-8l1-7Z",
+  check: "m4 12 5 5L20 6",
+  close: "m5 5 14 14M19 5 5 19",
+  plus: "M12 4v16M4 12h16",
+  settings: "M4 7h16M4 17h16M8 4v6m8 4v6",
+  swap: "M4 7h16l-4-4M20 17H4l4 4",
+  record: "M12 5a7 7 0 1 0 0 14 7 7 0 0 0 0-14Z",
+  sound: "M4 9h4l5-4v14l-5-4H4V9Zm12 0a4 4 0 0 1 0 6m3-9a8 8 0 0 1 0 12",
+  mute: "M4 9h4l5-4v14l-5-4H4V9Zm12 1 6 6m0-6-6 6",
+  stop: "M6 6h12v12H6Z",
+};
+export const icon = (name, size = 18) =>
+  `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="${icons[name] ?? icons.arena}"/></svg>`;
+export const iconTemplate = (name, size = 18) =>
+  html`<svg width=${size} height=${size} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d=${icons[name] ?? icons.arena} /></svg>`;

--- a/packages/viewer/tournament-view.js
+++ b/packages/viewer/tournament-view.js
@@ -1,0 +1,190 @@
+// The tournament panel as lit-html templates. A template says what the surface
+// should look like for a given report; the library patches only the parts that
+// changed, so a ranking that updates after every match does not rebuild its
+// table. Values inside a binding are escaped by the library: nothing here needs
+// escaping by hand.
+import { html, svg, nothing } from "lit-html";
+import { botName, botDetails } from "../bot-catalog.js";
+import { STYLE_AXES, formatStyleValue, styleLabel, styleProfiles } from "../tournament/style.js";
+import { INDEX_TERMS, compositeIndex } from "../tournament/composite.js";
+import { iconTemplate } from "./icons.js";
+import { clock } from "./format.js";
+
+const header = (title, tag) =>
+  html`<div class="ranking-header"><h2>${title}</h2><span class="tag">${tag}</span></div>`;
+
+const rows = (headers, body) => html`<div class="table-scroll">
+  <table>
+    <thead>
+      <tr>
+        ${headers.map((label) => html`<th>${label}</th>`)}
+      </tr>
+    </thead>
+    <tbody>
+      ${body}
+    </tbody>
+  </table>
+</div>`;
+
+export const emptyRanking = (title, body) =>
+  html`<div class="empty-ranking"><h2>${title}</h2><p>${body}</p></div>`;
+
+export function rankingTemplate(report) {
+  const format = report.format === "quick" ? "QUICK ROUNDS" : "ROUND ROBIN";
+  return html`${header(
+    report.published
+      ? "Published standings"
+      : report.status === "complete"
+        ? "Final ranking"
+        : "Provisional ranking",
+    report.published
+      ? `PUBLISHED · ${report.records.length} MATCHES · ${format}${
+          report.generatedAt ? " · " + report.generatedAt.slice(0, 10) : ""
+        }`
+      : `${report.records.length} / ${report.totalMatches} MATCHES · ${format} · ${report.status.toUpperCase()}`,
+  )}
+  ${rows(
+    ["#", "Controller", "Bradley–Terry", "95% CI", "Score %", "W / D / L", "Δ Flip",
+     "Ring-out + / −", "Mean energy", "First contact", "Violations / match", "Timeouts"],
+    report.ranking.map(
+      (r, i) => html`<tr>
+        <td class="rank-number">${String(i + 1).padStart(2, "0")}</td>
+        <td><strong>${botName(r)}</strong><small>${botDetails(r)}</small></td>
+        <td class="bt-score">${r.score.toFixed(1)}</td>
+        <td class="mono">${r.ci?.map((n) => n.toFixed(1)).join(" – ") ?? "—"}</td>
+        <td>${(r.winRate * 100).toFixed(1)}%</td>
+        <td class="mono">${r.wins} / ${r.draws} / ${r.matches - r.wins - r.draws}</td>
+        <td>${r.flipDifferential > 0 ? "+" : ""}${r.flipDifferential}</td>
+        <td>${r.ringOutsInflicted} / ${r.ringOutsTaken}</td>
+        <td>${r.meanEnergy.toFixed(1)}</td>
+        <td>${r.meanFirstContactTick === null ? "—" : (r.meanFirstContactTick / 60).toFixed(1) + " s"}</td>
+        <td>${r.violationsPerMatch.toFixed(2)}</td>
+        <td>${r.timeouts}</td>
+      </tr>`,
+    ),
+  )}`;
+}
+
+// One radar per controller: the axes are scaled against the rest of the roster,
+// so the shape compares controllers instead of measuring them absolutely.
+function radar(profile) {
+  const point = (index, radius) => {
+    const angle = (Math.PI * 2 * index) / STYLE_AXES.length - Math.PI / 2;
+    return [60 + radius * Math.cos(angle), 60 + radius * Math.sin(angle)];
+  };
+  const ring = (radius) =>
+    STYLE_AXES.map((_, i) => point(i, radius).map((n) => n.toFixed(1)).join(",")).join(" ");
+  const shape = STYLE_AXES.map((axis, i) =>
+    point(i, 12 + 34 * Math.min(1, Math.max(0, profile[axis.key])))
+      .map((n) => n.toFixed(1))
+      .join(","),
+  ).join(" ");
+  return html`<svg viewBox="-40 -8 200 142" role="img" aria-hidden="true">
+    <polygon class="radar-grid" points=${ring(46)} />
+    <polygon class="radar-grid" points=${ring(23)} />
+    ${STYLE_AXES.map((_, i) => {
+      const [x, y] = point(i, 46);
+      return svg`<line class="radar-grid" x1="60" y1="60" x2=${x.toFixed(1)} y2=${y.toFixed(1)} />`;
+    })}
+    <polygon class="radar-shape" points=${shape} />
+    ${STYLE_AXES.map((axis, i) => {
+      const [x, y] = point(i, 54);
+      // Left of the centre the text runs outwards to the left, right of it to the right.
+      const anchor = x > 61 ? "start" : x < 59 ? "end" : "middle";
+      const dx = anchor === "start" ? 4 : anchor === "end" ? -4 : 0;
+      const dy = y > 61 ? 8 : y < 59 ? 0 : 3;
+      return svg`<text class="radar-label" x=${(x + dx).toFixed(1)} y=${(y + dy).toFixed(1)}
+        text-anchor=${anchor}>${axis.short ?? axis.label}</text>`;
+    })}
+  </svg>`;
+}
+
+export function styleTemplate(report) {
+  const profiles = styleProfiles(report.ranking);
+  if (!profiles) return nothing;
+  return html`${header("Play style", "MEASURED OVER THE SAME MATCHES · SCALED ON THIS ROSTER")}
+  <div class="style-cards">
+    ${report.ranking.map(
+      (r, i) => html`<article class="style-card">
+        <header><strong>${botName(r)}</strong><span class="tag">${styleLabel(profiles[i])}</span></header>
+        ${radar(profiles[i])}
+        <dl>
+          ${STYLE_AXES.map(
+            (axis) => html`<div><dt>${axis.label}</dt><dd>${formatStyleValue(axis, r.style)}</dd></div>`,
+          )}
+        </dl>
+      </article>`,
+    )}
+  </div>`;
+}
+
+// Results and source folded into one number. The ranking stays the ranking.
+export function indexTemplate(report) {
+  const index = compositeIndex(report);
+  if (!index) return nothing;
+  return html`${header("Craft index", "RESULTS AND SOURCE · NOT THE RANKING")}
+  ${rows(
+    ["Controller", "Craft index", ...INDEX_TERMS.map((term) => `${term.label} · ${Math.round(term.weight * 100)}%`)],
+    report.ranking.map(
+      (row, i) => html`<tr>
+        <td><strong>${botName(row)}</strong></td>
+        <td class="bt-score">${index[i].index.toFixed(1)}</td>
+        ${INDEX_TERMS.map(
+          (term) => html`<td class="mono">${
+            index[i].terms[term.key] === null ? "—" : index[i].terms[term.key].toFixed(2)
+          }</td>`,
+        )}
+      </tr>`,
+    ),
+  )}`;
+}
+
+// Static source measurements, published with the standings.
+export function codeTemplate(report) {
+  const order = new Map(report.ranking.map((row, i) => [row.id, i]));
+  const measured = (report.bots ?? [])
+    .filter((bot) => bot.code)
+    .sort((x, y) => (order.get(x.id) ?? Infinity) - (order.get(y.id) ?? Infinity));
+  if (!measured.length) return nothing;
+  return html`${header("Implementation", "MEASURED FROM THE SUBMITTED SOURCE")}
+  ${rows(
+    ["Controller", "Language", "Lines", "Code", "Comments", "Functions", "Cyclomatic", "Max nesting", "Size"],
+    measured.map(
+      (bot) => html`<tr>
+        <td><strong>${botName(bot)}</strong></td>
+        <td>${bot.code.language}</td>
+        ${["lines", "codeLines", "commentLines", "functions", "complexity", "maxDepth"].map(
+          (key) => html`<td class="mono">${bot.code[key]}</td>`,
+        )}
+        <td class="mono">${(bot.code.bytes / 1024).toFixed(1)} kB</td>
+      </tr>`,
+    ),
+  )}`;
+}
+
+// The watch handler is bound to its own row: no delegated listener, no index
+// travelling through a data attribute.
+export function matchesTemplate(report, watch) {
+  if (!report.records.length) return nothing;
+  return html`${header("Completed matches", "WATCH WHILE THE TOURNAMENT RUNS")}
+  ${rows(
+    ["#", "Round", "Match", "Seed / spawn", "Result", "Replay"],
+    report.records
+      .map(
+        (r, i) => html`<tr>
+          <td>${i + 1}</td>
+          <td>${r.round}</td>
+          <td>${botName(report.bots[r.a])} vs ${botName(report.bots[r.b])}</td>
+          <td>${r.seed} / ${r.mirrored ? "Mirrored" : "Standard"}</td>
+          <td>
+            ${r.score === 0.5 ? "Draw" : botName(report.bots[r.score === 1 ? r.a : r.b]) + " wins"}
+            <small>${r.reason} · ${clock(r.ticks / 60)}</small>
+          </td>
+          <td>
+            <button class="button outline" @click=${() => watch(i)}>${iconTemplate("play")}Watch</button>
+          </td>
+        </tr>`,
+      )
+      .reverse(),
+  )}`;
+}

--- a/tests/tournament-view.test.js
+++ b/tests/tournament-view.test.js
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { nothing } from "lit-html";
+import {
+  rankingTemplate, styleTemplate, indexTemplate, codeTemplate, matchesTemplate,
+} from "../packages/viewer/tournament-view.js";
+
+// A lit template is data until something renders it, so it can be inspected
+// here without a DOM: the text is what the bindings would put on the page, the
+// handlers are the listeners the rows carry.
+function collect(node, out = { text: "", handlers: [] }) {
+  if (node == null || node === nothing) return out;
+  if (typeof node === "function") {
+    out.handlers.push(node);
+    return out;
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) collect(child, out);
+    return out;
+  }
+  if (node.strings && node.values) {
+    node.strings.forEach((chunk, i) => {
+      out.text += chunk;
+      if (i < node.values.length) collect(node.values[i], out);
+    });
+    return out;
+  }
+  out.text += String(node);
+  return out;
+}
+
+const style = () => ({
+  closingShare: 0.4, approachSpeed: 0.6, facingShare: 0.6, proximityShare: 0.5,
+  contactShare: 0.2, engagementRate: 7, wedgeShare: 0.66, speed: 1.2,
+  turnRate: 0.6, idleShare: 0.2, edgeShare: 0.03, spendRate: 13, recharges: 4, burns: 0,
+});
+const code = () => ({
+  language: "js", bytes: 2048, lines: 40, codeLines: 30, commentLines: 6,
+  blankLines: 4, functions: 3, statements: 35, complexity: 12, maxDepth: 3,
+});
+const report = (overrides = {}) => ({
+  format: "round-robin",
+  status: "complete",
+  totalMatches: 2,
+  generatedAt: "2026-01-02T03:04:05.000Z",
+  bots: [
+    { id: "alpha", model: "Alpha 1", provider: "OpenAI", code: code() },
+    { id: "beta", model: "Beta 2", provider: "Anthropic", code: code() },
+  ],
+  records: [
+    { a: 0, b: 1, seed: 4, mirrored: false, score: 1, reason: "ring-out", ticks: 600, firstContact: 100, round: 1 },
+    { a: 0, b: 1, seed: 7, mirrored: true, score: 0.5, reason: "timeout", ticks: 7200, firstContact: 60, round: 2 },
+  ],
+  ranking: [
+    {
+      id: "alpha", model: "Alpha 1", provider: "OpenAI", score: 120, ci: [100, 140],
+      matches: 2, wins: 1, draws: 1, winRate: 0.75, flipDifferential: 1,
+      ringOutsInflicted: 1, ringOutsTaken: 0, meanEnergy: 100, meanFirstContactTick: 120,
+      violationsPerMatch: 0, timeouts: 0, style: style(),
+    },
+    {
+      id: "beta", model: "Beta 2", provider: "Anthropic", score: 80, ci: [60, 100],
+      matches: 2, wins: 0, draws: 1, winRate: 0.25, flipDifferential: -1,
+      ringOutsInflicted: 0, ringOutsTaken: 1, meanEnergy: 90, meanFirstContactTick: null,
+      violationsPerMatch: 0.5, timeouts: 1, style: style(),
+    },
+  ],
+  ...overrides,
+});
+
+test("the ranking names the run it is showing and formats every column", () => {
+  const { text } = collect(rankingTemplate(report()));
+  assert.match(text, /Final ranking/);
+  assert.match(text, /2 \/ 2 MATCHES · ROUND ROBIN · COMPLETE/);
+  for (const value of ["Alpha 1", "Beta 2", "120.0", "100.0 – 140.0", "75.0", "1 / 1 / 0", "2.0 s", "0.50"])
+    assert.ok(text.includes(value), value);
+  // A controller that never made contact has no mean to show.
+  assert.ok(text.includes("—"), "missing values stay a dash");
+  const published = collect(rankingTemplate(report({ published: true }))).text;
+  assert.match(published, /Published standings/);
+  assert.match(published, /PUBLISHED · 2 MATCHES · ROUND ROBIN · 2026-01-02/);
+  assert.match(collect(rankingTemplate(report({ status: "running" }))).text, /Provisional ranking/);
+});
+
+test("play style, craft index and source metrics appear only when they can be measured", () => {
+  const full = report();
+  assert.match(collect(styleTemplate(full)).text, /Play style/);
+  assert.match(collect(indexTemplate(full)).text, /Craft index/);
+  assert.match(collect(codeTemplate(full)).text, /Implementation/);
+  const noStyle = report();
+  delete noStyle.ranking[1].style;
+  assert.equal(styleTemplate(noStyle), nothing);
+  const noCode = report();
+  noCode.bots = noCode.bots.map(({ code, ...bot }) => bot);
+  assert.equal(indexTemplate(noCode), nothing);
+  assert.equal(codeTemplate(noCode), nothing);
+});
+
+test("the completed matches are newest first and each row watches its own replay", () => {
+  const watched = [];
+  const full = report();
+  const { text, handlers } = collect(matchesTemplate(full, (i) => watched.push(i)));
+  assert.match(text, /Completed matches/);
+  assert.ok(text.includes("Draw"), "a drawn match says so");
+  assert.ok(text.includes("Alpha 1 wins"), "a decided match names the winner");
+  assert.ok(text.includes("02:00"), "match time is mm:ss");
+  assert.equal(handlers.length, full.records.length);
+  handlers[0]();
+  assert.deepEqual(watched, [full.records.length - 1], "the first row is the last match played");
+  assert.equal(matchesTemplate(report({ records: [] }), () => {}), nothing);
+});


### PR DESCRIPTION
The tournament panel built its five tables as one long HTML string each, then dropped them in with `innerHTML`. Adding a column meant editing a 300 character line and remembering `esc()` on every value, and every update rebuilt the whole table.

`lit-html` (3 kB, no web components, no build step) now renders those surfaces from templates in `packages/viewer/tournament-view.js`. Bindings are escaped by the library, so `esc()` is gone from this panel; the Watch button binds its own handler instead of a delegated listener reading a `data-` index; an updated ranking patches the cells that changed. `app.js` loses 126 lines. The icon table and the match clock moved to their own modules so both the string code and the templates can use them.

Only this panel: the rest of the app is untouched, and the arena HUD stays imperative because it updates every frame.

`tests/tournament-view.test.js` inspects the templates without a DOM: a lit template is data until it is rendered, so the columns, the empty cases and the per-row handler can all be asserted in node.

Draft because the panel still needs a look in a real browser.