### PR TITLE
JavaScript-only controllers, acorn static gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.angular/
 artifacts/
 .env
 .env.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ This is the llms-robot-arena project. Repository: [nigrosimone/llms-robot-arena]
 
 ## Scope and public information
 
-This file is the single reference for game rules, TypeScript contracts, bot development, evaluation, local operation, and publication. Use the rules and constants below and evaluate results under matching rules, engine versions and runtime budgets. The public example in this document may be used as a starting template, without opening any other bot implementation.
+This file is the single reference for game rules, the bot contract, bot development, evaluation, local operation, and publication. Use the rules and constants below and evaluate results under matching rules, engine versions and runtime budgets. The public example in this document may be used as a starting template, without opening any other bot implementation.
 
 Keep this file focused on instructions for agents. Omit camera controls, visual styling details and end-user interface walkthroughs.
 
@@ -27,7 +27,7 @@ For general project searches, explicitly exclude `packages/bots/**`, `dist/**`, 
 
 ## Implementing a bot
 
-1. Use the requested name and create one file at `packages/bots/<bot-id>.js` or `.ts`. Never overwrite another bot. If no ID was supplied, choose a descriptive unused filename without opening existing bot files.
+1. Use the requested name and create one file at `packages/bots/<bot-id>.js`. Never overwrite another bot. If no ID was supplied, choose a descriptive unused filename without opening existing bot files.
 2. Export exactly one function: `tick(sensors, memory)`, returning `{ actions: { thrust, turn }, memory }`. Use no imports, dependencies, extra exports, network, filesystem, clock, randomness APIs, or dynamic code generation.
 3. Treat sensors and incoming memory as immutable. Persistent state belongs only in returned JSON memory; each tick gets a fresh module scope. Initial memory is `null`. Return finite numeric actions and strict JSON memory within the documented 64 KiB limit.
 4. Design using the public rules and sensor interface. Do not modify physics, energy, collision thresholds, runtime budgets, gates, fixtures, ranking, or an opponent to help your bot win. Report an engine issue separately.
@@ -335,6 +335,8 @@ A **pure** function. No global state or side effects. All persistent state passe
 
 ### Types
 
+These declarations describe the data a controller receives. The file you write is plain JavaScript: the gate parses it and rejects type annotations.
+
 ```ts
 type RobotStatus = 'active' | 'flipped' | 'recovering';
 
@@ -442,7 +444,7 @@ All values use the **world frame**. There are no helpers or ready-made `angleTo(
 
 ### Code constraints
 
-- One TypeScript or JavaScript file, ESM, with a single export: `tick`.
+- One JavaScript file, ESM, with a single export: `tick`. TypeScript syntax is rejected by the gate.
 - No `import` statements or dependencies.
 - Forbidden: `Math.random`, `Date`, `performance`, `fetch`, `setTimeout`, `globalThis`, `eval`, `Function`, `WeakRef`. The worker removes them from scope.
 - `Math.sin/cos/atan2/sqrt/hypot` are allowed.
@@ -450,8 +452,8 @@ All values use the **world frame**. There are no helpers or ready-made `angleTo(
 
 ### Minimal example
 
-```ts
-export function tick(s: Sensors, m: Memory) {
+```js
+export function tick(s, m) {
   const dx = s.opponent.x - s.self.x;
   const dy = s.opponent.y - s.self.y;
   const bearing = Math.atan2(dy, dx);
@@ -575,7 +577,7 @@ These values are checked against the simulator by the project tests. Update this
 
 ## Standalone bot submissions
 
-When asked to return a standalone bot submission as your response, respond with **one JavaScript or TypeScript file**, using ESM and **exactly one export** named `tick`. Do not include explanations, text outside the code, or any `import`. The file will run as submitted in the runtime described above and must pass all eight conformity checks before entering the arena.
+When asked to return a standalone bot submission as your response, respond with **one JavaScript file**, using ESM and **exactly one export** named `tick`. Do not include explanations, text outside the code, or any `import`. The file will run as submitted in the runtime described above and must pass all eight conformity checks before entering the arena.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ The complete match is calculated before playback. You can pause, scrub through t
 | Area | What you can do |
 | --- | --- |
 | **Arena** | Run individual matches and watch the results in 3D, with energy bars, robot status and an event log. |
-| **Bot Lab** | Create or edit a JavaScript or TypeScript controller, check that it follows the bot contract, and download its source. |
+| **Bot Lab** | Create or edit a JavaScript controller, check that it follows the bot contract, and download its source. |
 | **Tournament** | Compare selected bots across repeated matches and export rankings and reports. |
 | **Rules** | Read a short overview of the game mechanics. |
 
-Bot Lab changes last for the current browser session. Download your controller to keep a copy. The editor preserves its JavaScript or TypeScript extension; use the file-type selector when changing languages.
+Bot Lab changes last for the current browser session. Download your controller to keep a copy.
 
 ## Where do the LLMs come in?
 
-An LLM writes the controller before the match. During the match, that JavaScript or TypeScript program receives the robot's sensors and chooses how much to drive and turn. It runs automatically inside an isolated execution environment; the arena makes no LLM API calls.
+An LLM writes the controller before the match. During the match, that JavaScript program receives the robot's sensors and chooses how much to drive and turn. It runs automatically inside an isolated execution environment; the arena makes no LLM API calls.
 
 This makes the project a way to explore how well coding agents turn a shared specification into working strategies. You can also write a controller yourself and test it in your local arena.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@jitl/quickjs-singlefile-browser-release-sync": "0.31.0",
         "@noble/hashes": "1.8.0",
+        "acorn": "8.18.0",
         "quickjs-emscripten": "0.31.0",
         "three": "0.180.0",
         "typescript": "5.9.3"
@@ -524,6 +525,18 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/esbuild": {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   },
   "dependencies": {
     "three": "0.180.0",
+    "acorn": "8.18.0",
     "quickjs-emscripten": "0.31.0",
     "@jitl/quickjs-singlefile-browser-release-sync": "0.31.0",
-    "typescript": "5.9.3",
     "@noble/hashes": "1.8.0"
   },
-  "devDependencies": { "esbuild": "0.25.10" }
+  "devDependencies": { "esbuild": "0.25.10", "typescript": "5.9.3" }
 }

--- a/packages/bot-catalog.js
+++ b/packages/bot-catalog.js
@@ -23,8 +23,8 @@ export function validateBotDefinitions(entries, { catalog = false } = {}) {
         throw new Error(`Bot ${key} must be a non-empty string or null.`);
     }
     if (catalog) {
-      if (!/^packages\/bots\/[a-zA-Z0-9_-]+\.(js|ts)$/.test(bot.file))
-        throw new Error("Catalog files must be JS or TS files directly in packages/bots/.");
+      if (!/^packages\/bots\/[a-zA-Z0-9_-]+\.js$/.test(bot.file))
+        throw new Error("Catalog files must be JS files directly in packages/bots/.");
       if (files.has(bot.file.toLowerCase())) throw new Error("Catalog bot files must be unique.");
       files.add(bot.file.toLowerCase());
     }

--- a/packages/runtime/compile.js
+++ b/packages/runtime/compile.js
@@ -1,4 +1,8 @@
-import ts from "typescript";
+// A controller is one JavaScript file. Parsing it is the whole static gate:
+// the source is read, never executed, and what comes out is the same text with
+// the export keyword removed, so a runtime error still points at the line the
+// author wrote.
+import { parse } from "acorn";
 const forbidden = new Set([
   "Date",
   "performance",
@@ -23,94 +27,82 @@ const forbidden = new Set([
   "Atomics",
   "SharedArrayBuffer",
 ]);
+const isNode = (value) =>
+  value && typeof value === "object" && typeof value.type === "string";
+// `o.document` names a property of someone else's object; `document` alone is
+// the host global the sandbox refuses to expose.
+const isPropertyName = (node, parent) =>
+  !!parent &&
+  !parent.computed &&
+  ((parent.type === "MemberExpression" && parent.property === node) ||
+    (["Property", "PropertyDefinition", "MethodDefinition"].includes(parent.type) &&
+      parent.key === node));
+
+function scan(node, parent) {
+  if (node.type === "ImportExpression")
+    throw new Error("Dynamic imports are forbidden.");
+  if (
+    node.type === "Identifier" &&
+    !isPropertyName(node, parent) &&
+    forbidden.has(node.name)
+  )
+    throw new Error("Forbidden global: " + node.name);
+  if (
+    node.type === "MemberExpression" &&
+    node.object.type === "Identifier" &&
+    node.object.name === "Math"
+  ) {
+    const key = node.computed
+      ? node.property.type === "Literal"
+        ? node.property.value
+        : null
+      : node.property.name;
+    if (key === "random") throw new Error("Math.random is forbidden.");
+  }
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      for (const child of value) if (isNode(child)) scan(child, node);
+    } else if (isNode(value)) scan(value, node);
+  }
+}
+
 export function compileBot(source) {
   if (
     typeof source !== "string" ||
     new TextEncoder().encode(source).length > 262144
   )
-    throw new Error("The controller must be a JS/TS file no larger than 256 KB.");
-  const tree = ts.createSourceFile(
-    "bot.ts",
-    source,
-    ts.ScriptTarget.ES2022,
-    true,
-    ts.ScriptKind.TS,
-  );
-  if (tree.parseDiagnostics.length)
-    throw new Error(
-      ts.flattenDiagnosticMessageText(
-        tree.parseDiagnostics[0].messageText,
-        " ",
-      ),
-    );
-  let exports = [];
-  for (const n of tree.statements) {
+    throw new Error("The controller must be a JS file no larger than 256 KB.");
+  let tree;
+  try {
+    tree = parse(source, { ecmaVersion: 2022, sourceType: "module" });
+  } catch (e) {
+    throw new Error(e.message);
+  }
+  const exports = [];
+  const keywords = [];
+  for (const node of tree.body) {
+    if (node.type === "ExportDefaultDeclaration")
+      throw new Error("Use export function tick, not export default.");
     if (
-      ts.isImportDeclaration(n) ||
-      ts.isImportEqualsDeclaration(n) ||
-      ts.isExportDeclaration(n) ||
-      ts.isExportAssignment(n)
+      node.type === "ImportDeclaration" ||
+      node.type === "ExportAllDeclaration" ||
+      (node.type === "ExportNamedDeclaration" && !node.declaration)
     )
       throw new Error("Only one tick export and no imports are allowed.");
-    if (n.modifiers?.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword))
-      throw new Error("Use export function tick, not export default.");
-    if (n.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)) {
-      if (ts.isFunctionDeclaration(n)) exports.push(n.name?.text);
-      else if (ts.isVariableStatement(n))
-        exports.push(...n.declarationList.declarations.map((d) => d.name.text));
-      else throw new Error("The only allowed export is tick.");
-    }
+    if (node.type !== "ExportNamedDeclaration") continue;
+    const declaration = node.declaration;
+    if (declaration.type === "FunctionDeclaration") exports.push(declaration.id?.name);
+    else if (declaration.type === "VariableDeclaration")
+      for (const declared of declaration.declarations)
+        exports.push(declared.id.type === "Identifier" ? declared.id.name : null);
+    else throw new Error("The only allowed export is tick.");
+    keywords.push([node.start, declaration.start]);
   }
   if (exports.length !== 1 || exports[0] !== "tick")
     throw new Error("The module must export only tick.");
-  function scan(n) {
-    const propertyName =
-      n.parent &&
-      ((ts.isPropertyAccessExpression(n.parent) && n.parent.name === n) ||
-        (ts.isPropertyAssignment(n.parent) && n.parent.name === n));
-    if (ts.isIdentifier(n) && !propertyName && forbidden.has(n.text))
-      throw new Error("Forbidden global: " + n.text);
-    if (n.kind === ts.SyntaxKind.ImportKeyword)
-      throw new Error("Dynamic imports are forbidden.");
-    if (
-      (ts.isPropertyAccessExpression(n) || ts.isElementAccessExpression(n)) &&
-      n.expression.getText(tree) === "Math"
-    ) {
-      const key = ts.isPropertyAccessExpression(n)
-        ? n.name.text
-        : ts.isStringLiteral(n.argumentExpression)
-          ? n.argumentExpression.text
-          : null;
-      if (key === "random") throw new Error("Math.random is forbidden.");
-    }
-    ts.forEachChild(n, scan);
-  }
-  scan(tree);
-  const plain = ts.factory.updateSourceFile(
-    tree,
-    tree.statements.map((n) =>
-      n.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
-        ? ts.factory.replaceModifiers(
-            n,
-            n.modifiers.filter((m) => m.kind !== ts.SyntaxKind.ExportKeyword),
-          )
-        : n,
-    ),
-  );
-  const result = ts.transpileModule(ts.createPrinter().printFile(plain), {
-    compilerOptions: {
-      target: ts.ScriptTarget.ES2022,
-      module: ts.ModuleKind.None,
-      isolatedModules: true,
-    },
-    reportDiagnostics: true,
-  });
-  const errors = result.diagnostics?.filter(
-    (d) => d.category === ts.DiagnosticCategory.Error,
-  );
-  if (errors?.length)
-    throw new Error(
-      ts.flattenDiagnosticMessageText(errors[0].messageText, " "),
-    );
-  return result.outputText;
+  scan(tree, null);
+  let plain = source;
+  for (const [from, to] of keywords.reverse())
+    plain = plain.slice(0, from) + plain.slice(to);
+  return plain;
 }

--- a/packages/runtime/gate-cli.js
+++ b/packages/runtime/gate-cli.js
@@ -4,7 +4,7 @@ import { BotClient } from "./client.js";
 import { gateBot } from "./gate.js";
 const path = process.argv[2];
 if (!path) {
-  console.error("Usage: npm run gate -- controller.ts");
+  console.error("Usage: npm run gate -- controller.js");
   process.exit(1);
 }
 const client = new BotClient(

--- a/packages/runtime/gate.js
+++ b/packages/runtime/gate.js
@@ -16,7 +16,7 @@ export async function gateBot(client, source, budgetMode = "fuel") {
   try {
     await client.request({ type: "init", source, budgetMode: "fuel" });
     checks.push(
-      { name: "Export tick · JS / TypeScript", pass: true },
+      { name: "Export tick · JavaScript", pass: true },
       { name: "Static analysis and isolated scope", pass: true },
     );
   } catch (e) {

--- a/packages/site/content.js
+++ b/packages/site/content.js
@@ -44,7 +44,7 @@ export const RULE_CARDS = [
   {
     number: "06 / BENCHMARK",
     title: "Conformance before competition.",
-    body: `<p>One JS or TS file, one tick export, no imports or external APIs. QuickJS runs in a Worker sandbox. Public tests check execution, purity, memory and timing.</p>`,
+    body: `<p>One JavaScript file, one tick export, no imports or external APIs. QuickJS runs in a Worker sandbox. Public tests check execution, purity, memory and timing.</p>`,
   },
 ];
 

--- a/packages/site/prerender.js
+++ b/packages/site/prerender.js
@@ -327,7 +327,7 @@ function labPage(example, baseUrl) {
     app: true,
     title: tabTitle("lab"),
     description:
-      "Write an autonomous robot controller in JavaScript or TypeScript, check it against the contract and run it in the browser: one tick function, thrust and turn, 64 KB of memory.",
+      "Write an autonomous robot controller in JavaScript, check it against the contract and run it in the browser: one tick function, thrust and turn, 64 KB of memory.",
     baseUrl,
     schema: [
       {
@@ -353,7 +353,7 @@ function labPage(example, baseUrl) {
     )}
   <div class="rules-grid">
    <article class="info-card">${CONTRACT_CARD}</article>
-   <article class="info-card"><span class="rule-number">SANDBOX</span><h2>QuickJS in a worker.</h2><p>One JavaScript or TypeScript file, one <code>tick</code> export, no imports and no host APIs. Sensors and memory arrive frozen and every call gets a fresh module scope, so nothing carries over except the memory you return. It runs as QuickJS WebAssembly, one worker per robot.</p></article>
+   <article class="info-card"><span class="rule-number">SANDBOX</span><h2>QuickJS in a worker.</h2><p>One JavaScript file, one <code>tick</code> export, no imports and no host APIs. Sensors and memory arrive frozen and every call gets a fresh module scope, so nothing carries over except the memory you return. It runs as QuickJS WebAssembly, one worker per robot.</p></article>
    <article class="info-card"><span class="rule-number">CONFORMANCE GATE</span><h2>Checked before it fights.</h2><p>200 snapshots and 600 inert ticks look at execution, purity, memory and timing. They say nothing about strategy: passing the gate means the controller is admissible, not that it is any good.</p></article>
   </div>
   ${
@@ -423,7 +423,7 @@ function botsPage(bots, standings, baseUrl) {
     main: `${heading(
       "CONTROLLERS",
       "One function. Two commands",
-      "Every controller is a single JavaScript or TypeScript file exporting <code>tick(sensors, memory)</code> and returning thrust and turn. Same robot, same arena, same energy: the code is the only variable.",
+      "Every controller is a single JavaScript file exporting <code>tick(sensors, memory)</code> and returning thrust and turn. Same robot, same arena, same energy: the code is the only variable.",
     )}
   ${card(
     "Registered controllers",
@@ -439,7 +439,6 @@ function botPage(bot, standings, baseUrl) {
   const row = position >= 0 ? standings.ranking[position] : null;
   const record = standings?.bots.find((entry) => entry.id === bot.id) ?? null;
   const profiles = standings ? styleProfiles(standings.ranking) : null;
-  const language = record?.code?.language === "ts" ? "TypeScript" : "JavaScript";
   const name = botName(bot);
   const results = row
     ? card(
@@ -482,7 +481,7 @@ function botPage(bot, standings, baseUrl) {
         "Source metrics",
         "PARSED, NEVER EXECUTED",
         facts([
-          ["Language", language],
+          ["Language", "JavaScript"],
           ["Total lines", String(record.code.lines)],
           ["Code lines", String(record.code.codeLines)],
           ["Comment lines", String(record.code.commentLines)],
@@ -510,7 +509,7 @@ function botPage(bot, standings, baseUrl) {
         description: `Autonomous robot controller for llms-robot-arena. ${botDetails(bot)}.`,
         url: absolute(baseUrl, `bots/${botSlug(bot)}/`),
         codeRepository: SITE.repository,
-        programmingLanguage: language,
+        programmingLanguage: "JavaScript",
         codeSampleType: "full solution",
         isPartOf: { "@type": "WebSite", name: SITE.name, url: baseUrl },
         ...(bot.provider ? { creator: { "@type": "Organization", name: bot.provider } } : {}),
@@ -604,7 +603,7 @@ function llmsTxt(bots, standings, baseUrl) {
 
 > ${SITE.tagline} A deterministic 3D arena where autonomous controllers, most of them written by an LLM, fight one against one. Every duel is reproducible from its seed and replayed frame by frame.
 
-A match lasts 120 seconds at 60 Hz on a 16 × 16 m platform that starts shrinking after 60 seconds. A controller is one JavaScript or TypeScript file exporting \`tick(sensors, memory)\` and returning thrust and turn. It runs in a QuickJS sandbox with an instruction budget and 64 KB of memory. Controllers written by different models are ranked with a regularized Bradley–Terry fit over a round robin.
+A match lasts 120 seconds at 60 Hz on a 16 × 16 m platform that starts shrinking after 60 seconds. A controller is one JavaScript file exporting \`tick(sensors, memory)\` and returning thrust and turn. It runs in a QuickJS sandbox with an instruction budget and 64 KB of memory. Controllers written by different models are ranked with a regularized Bradley–Terry fit over a round robin.
 
 ## Pages
 

--- a/packages/viewer/app.js
+++ b/packages/viewer/app.js
@@ -5,7 +5,7 @@ import { stringifyReplay, parseReplay } from "../sim/replay.js";
 import builtins from "arena:bots";
 import { robotColor } from "./palette.js";
 import { botName, botDetails } from "../bot-catalog.js";
-import { sortedBotOptions, controllerExtension, controllerFilename } from "./controllers.js";
+import { sortedBotOptions, controllerFilename } from "./controllers.js";
 import { exhibitionSchedule } from "../tournament/exhibition.js";
 import { STYLE_AXES, formatStyleValue, styleLabel, styleProfiles } from "../tournament/style.js";
 import { INDEX_TERMS, compositeIndex } from "../tournament/composite.js";
@@ -137,7 +137,7 @@ document.querySelector("#app").innerHTML = `
  </section>
  <section id="panel-lab" class="panel"${shown("lab")}>
   <div class="page-heading"><div><div class="eyebrow">CONTROLLER WORKSPACE <span>/ 02</span></div><h1>Your code. Your robot<span>.</span></h1></div><button id="new-bot" class="button accent">${icon("plus")}New controller</button></div>
-  <div class="lab-layout"><div class="editor-panel"><div class="editor-toolbar"><select id="edit-bot" aria-label="Controller to edit"></select><select id="source-language" aria-label="Controller file type"><option value="js">JavaScript (.js)</option><option value="ts">TypeScript (.ts)</option></select></div><div class="editor-file">${icon("code", 16)}<span id="editor-filename">controller.js</span><span id="unsaved" class="unsaved" hidden>Unsaved changes</span></div><div class="editor-body"><pre id="line-numbers" aria-hidden="true"></pre><textarea id="code-editor" aria-label="Controller source" spellcheck="false" autocapitalize="off" autocomplete="off" wrap="off"></textarea></div><div class="editor-footer"><input id="bot-name" aria-label="Model name" placeholder="Model name" maxlength="80"><select id="bot-provider" aria-label="Model provider"><option value="">No provider</option><option>OpenAI</option><option>Anthropic</option></select><button id="download-bot" class="button outline">${icon("download")}.js file</button><button id="save-bot" class="button accent">Save controller</button></div></div>
+  <div class="lab-layout"><div class="editor-panel"><div class="editor-toolbar"><select id="edit-bot" aria-label="Controller to edit"></select></div><div class="editor-file">${icon("code", 16)}<span id="editor-filename">controller.js</span><span id="unsaved" class="unsaved" hidden>Unsaved changes</span></div><div class="editor-body"><pre id="line-numbers" aria-hidden="true"></pre><textarea id="code-editor" aria-label="Controller source" spellcheck="false" autocapitalize="off" autocomplete="off" wrap="off"></textarea></div><div class="editor-footer"><input id="bot-name" aria-label="Model name" placeholder="Model name" maxlength="80"><select id="bot-provider" aria-label="Model provider"><option value="">No provider</option><option>OpenAI</option><option>Anthropic</option></select><button id="download-bot" class="button outline">${icon("download")}.js file</button><button id="save-bot" class="button accent">Save controller</button></div></div>
    <aside class="lab-sidebar"><div class="info-card">${CONTRACT_CARD}</div><div class="info-card gate-card"><div class="eyebrow">CONFORMANCE GATE</div><h2>Validate the contract.</h2><p>200 snapshots and 600 inert ticks. These checks offer no combat advice.</p><button id="run-gate" class="button outline full-width">${icon("check")}Check controller</button><div id="gate-results" aria-live="polite"></div></div><p class="side-hint">Edits here are iterative experimentation. For a one-shot benchmark, follow AGENTS.md and use the project CLI.</p></aside>
   </div>
  </section>
@@ -925,8 +925,6 @@ function loadEditor(index) {
   editing = index;
   $("#code-editor").value = bots[index].source;
   $("#bot-name").value = botName(bots[index]);
-  $("#source-language").value = controllerExtension(bots[index]);
-  updateEditorFile();
   $("#bot-provider").value = bots[index].provider ?? "";
   $("#unsaved").hidden = true;
   $("#gate-results").innerHTML = "";
@@ -938,15 +936,6 @@ $("#code-editor").oninput = () => {
   $("#unsaved").hidden = false;
 };
 $("#bot-name").oninput = $("#bot-provider").onchange = () => { $("#unsaved").hidden = false; };
-function updateEditorFile() {
-  const extension = $("#source-language").value;
-  $("#editor-filename").textContent = `controller.${extension}`;
-  $("#download-bot").innerHTML = `${icon("download")}.${extension} file`;
-}
-$("#source-language").onchange = () => {
-  updateEditorFile();
-  $("#unsaved").hidden = false;
-};
 $("#code-editor").onscroll = (e) =>
   ($("#line-numbers").scrollTop = e.target.scrollTop);
 $("#code-editor").onkeydown = (e) => {
@@ -974,7 +963,6 @@ $("#new-bot").onclick = () => {
     provider: null,
     provenance: "iterative",
     source: template.source,
-    extension: controllerExtension(template),
   });
   refreshBotOptions();
   $("#edit-bot").value = bots.length - 1;
@@ -993,7 +981,6 @@ $("#save-bot").onclick = () => {
     provider: $("#bot-provider").value || null,
     provenance: "iterative",
     source: $("#code-editor").value,
-    extension: $("#source-language").value,
   };
   const index = editing < builtins.length ? bots.length : editing;
   bots[index] = copy;
@@ -1004,7 +991,7 @@ $("#save-bot").onclick = () => {
 };
 $("#download-bot").onclick = () =>
   download(
-    controllerFilename($("#bot-name").value, $("#source-language").value),
+    controllerFilename($("#bot-name").value),
     $("#code-editor").value,
     "text/plain",
   );

--- a/packages/viewer/controllers.js
+++ b/packages/viewer/controllers.js
@@ -7,12 +7,6 @@ export function sortedBotOptions(bots) {
     a.bot.id.localeCompare(b.bot.id, "en"));
 }
 
-export function controllerExtension(bot) {
-  if (["js", "ts"].includes(bot.extension)) return bot.extension;
-  return bot.file?.endsWith(".ts") ? "ts" : "js";
-}
-
-export function controllerFilename(name, extension) {
-  return (name.trim().replace(/[^a-zA-Z0-9_-]/g, "-") || "controller") +
-    (extension === "ts" ? ".ts" : ".js");
+export function controllerFilename(name) {
+  return (name.trim().replace(/[^a-zA-Z0-9_-]/g, "-") || "controller") + ".js";
 }

--- a/packages/viewer/public/style.css
+++ b/packages/viewer/public/style.css
@@ -1425,9 +1425,6 @@ button svg {
   overflow: hidden;
   background: var(--panel);
 }
-#source-language {
-  margin-left: auto;
-}
 #tournament-format {
   max-width: 100%;
 }

--- a/packages/viewer/serve.js
+++ b/packages/viewer/serve.js
@@ -14,7 +14,6 @@ const types = {
   ".md": "text/markdown",
   ".txt": "text/plain",
   ".xml": "application/xml",
-  ".ts": "text/plain",
   ".zip": "application/zip",
   ".wasm": "application/wasm",
   ".svg": "image/svg+xml",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -44,9 +44,7 @@ await build({
         b.onLoad({ filter: /.*/, namespace: "bot-catalog" }, async () => ({
           contents:
             "export default " + JSON.stringify(
-              bots.map(({ file, ...bot }) => ({
-                ...bot, extension: file.endsWith(".ts") ? "ts" : "js",
-              })),
+              bots.map(({ file, ...bot }) => bot),
             ),
           loader: "js",
         }));

--- a/tests/bot-catalog.test.js
+++ b/tests/bot-catalog.test.js
@@ -11,7 +11,7 @@ import { renderCSV, renderReport } from "../packages/tournament/report.js";
 
 const pair = () => [
   { id: "alpha", model: "Alpha Model", provider: "OpenAI", thinking: "ultra", harness: "Codex", file: "packages/bots/alpha.js", provenance: "iterative" },
-  { id: "beta", model: "Beta Model", provider: "Anthropic", thinking: "max", harness: "Claude Code", file: "packages/bots/beta.ts" },
+  { id: "beta", model: "Beta Model", provider: "Anthropic", thinking: "max", harness: "Claude Code", file: "packages/bots/beta.js" },
 ];
 
 test("registered files exist and ID selections resolve from any manifest directory without reading sources", async () => {
@@ -46,10 +46,10 @@ test("catalog validation rejects duplicates, missing metadata and paths outside 
 
 test("manifests mix catalog IDs with custom definitions and retain legacy object support", () => {
   const external = resolve(projectRoot, "external-manifests");
-  const custom = { id: "custom", model: "Custom Model", file: "./controller.ts" };
+  const custom = { id: "custom", model: "Custom Model", file: "./controller.js" };
   const entries = resolveBotDefinitions([botCatalog[0].id, custom], external);
   assert.equal(entries[0].file, resolve(projectRoot, botCatalog[0].file));
-  assert.equal(entries[1].file, resolve(external, "controller.ts"));
+  assert.equal(entries[1].file, resolve(external, "controller.js"));
   assert.throws(() => resolveBotDefinitions(["missing-id", custom], external), /Unknown catalog bot/);
   assert.throws(() => resolveBotDefinitions([botCatalog[0].id, botCatalog[0].id]), /unique/);
   assert.throws(() => resolveBotDefinitions([custom, { ...custom, id: "empty", file: " " }]), /non-empty/);

--- a/tests/controllers.test.js
+++ b/tests/controllers.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { sortedBotOptions, controllerExtension, controllerFilename } from "../packages/viewer/controllers.js";
+import { sortedBotOptions, controllerFilename } from "../packages/viewer/controllers.js";
 
 test("alphabetical selectors retain original bot indices and leave the roster untouched", () => {
   const bots = ["Zulu", "alpha", "Beta"].map((model, i) => ({ id: String(i), model, provider: null }));
@@ -9,13 +9,8 @@ test("alphabetical selectors retain original bot indices and leave the roster un
   assert.deepEqual(bots, before);
 });
 
-test("controller downloads preserve JS and TS types, including explicit language changes", () => {
-  assert.equal(controllerExtension({ file: "packages/bots/fixture.js" }), "js");
-  assert.equal(controllerExtension({ file: "packages/bots/fixture.ts" }), "ts");
-  assert.equal(controllerExtension({ extension: "ts" }), "ts");
-  assert.equal(controllerExtension({ extension: "js", file: "fixture.ts" }), "js");
-  assert.equal(controllerExtension({}), "js");
-  assert.equal(controllerFilename("Example bot", "js"), "Example-bot.js");
-  assert.equal(controllerFilename("Example bot", "ts"), "Example-bot.ts");
-  assert.equal(controllerFilename("", "js"), "controller.js");
+test("a downloaded controller is always a JS file with a safe name", () => {
+  assert.equal(controllerFilename("Example bot"), "Example-bot.js");
+  assert.equal(controllerFilename(" Ünïcode / path "), "-n-code---path.js");
+  assert.equal(controllerFilename(""), "controller.js");
 });

--- a/tests/runtime.test.js
+++ b/tests/runtime.test.js
@@ -14,20 +14,34 @@ const using = async (src, fn) => {
     bot.dispose();
   }
 };
-test("AST accepts annotated TypeScript; rejects imports, extra exports and banned globals", () => {
-  assert.ok(
-    compileBot(
-      "type Memory=unknown; export function tick(s: any,m: Memory){return {actions:{thrust:0,turn:0},memory:m}}",
-    ),
+test("the gate keeps the tick export, and rejects TypeScript, imports, extra exports and banned globals", () => {
+  // The export keyword is dropped and nothing else is rewritten.
+  assert.equal(
+    compileBot("export function tick(s, m) { return { actions: { thrust: 0, turn: 0 }, memory: m }; }"),
+    "function tick(s, m) { return { actions: { thrust: 0, turn: 0 }, memory: m }; }",
   );
+  // A property may be named like a forbidden global; the global itself may not.
+  assert.ok(compileBot("export function tick(s, m) { return { actions: s.document, memory: m }; }"));
   for (const src of [
     'import x from "x"; export function tick(){}',
     "export function tick(){} export const x=1",
     "export function tick(){return Math.random()}",
     "export function tick(){return Date.now()}",
     'export function tick(){return import("fs")}',
+    "export function tick(s: any){}",
+    "type M = unknown; export function tick(){}",
+    "export default function tick(){}",
+    "function tick(){}; export { tick }",
   ])
     assert.throws(() => compileBot(src));
+});
+test("the starting template published in the specification passes the gate", async () => {
+  const specification = await readFile(new URL("../AGENTS.md", import.meta.url), "utf8");
+  const example = specification.match(
+    /### Minimal example\s+```\w*\n([\s\S]*?)```/,
+  )?.[1];
+  assert.ok(example, "the specification must publish a starting template");
+  assert.ok(compileBot(example));
 });
 test("baseline has finite outputs on 200 edge snapshots and bounded memory through 600 inert ticks", async () => {
   const source = await readFile(


### PR DESCRIPTION
The bot worker shipped 4.1 MB, and 3.4 MB of that was the TypeScript compiler. It was not there to transpile: `compile.js` uses it as the static gate for every controller, JS ones included, to reject imports, check the single `tick` export and refuse forbidden globals.

Controllers are JavaScript only now, and the gate parses with acorn. The worker drops from 3.5 MB to 126 kB. Same rules as before, plus TypeScript syntax is now a parse error; the output is the original source with the `export` keyword removed and nothing else rewritten, so a runtime error still points at the line the author wrote. The editor loses its language selector, the catalog only accepts `.js`, and the starting template in AGENTS.md is now JavaScript.

TypeScript stays as a dev dependency: `code-metrics.js` still parses with it to measure the published standings, and swapping that parser would move the numbers already published.

Replay state hashes, ticks and outcomes are identical on three fixed matches across five controllers, so the fuel budget is unchanged and the published standings stay comparable. A new test compiles the template published in AGENTS.md, so the page cannot advertise a controller the gate would reject.